### PR TITLE
fixing tests due to the lite data file changes

### DIFF
--- a/dd/results_hash_test.go
+++ b/dd/results_hash_test.go
@@ -616,7 +616,7 @@ func TestMatchDeviceId(t *testing.T) {
 		}{
 			{uaMobile, "true"},
 			{uaDesktop, "false"},
-			{uaMediaHub, "false"},
+			{uaMediaHub, "true"},
 		}
 
 		// Create results hash. Using separate results for match User-Agent


### PR DESCRIPTION
with the latest data file the uaMediaHub UA is now identified as isMobile=true