### PR TITLE
onpremise engine improvments

### DIFF
--- a/onpremise/file_pulling.go
+++ b/onpremise/file_pulling.go
@@ -40,9 +40,11 @@ func (p *Engine) scheduleFilePulling() {
 		case <-p.stopCh:
 			return
 		default:
-			if retryAttempts > 5 && !p.isManagerInitialized {
-				p.rdySignal <- ErrTooManyRetries
-				return
+			if p.maxRetries > 0 {
+				if retryAttempts > p.maxRetries && !p.isManagerInitialized {
+					p.rdySignal <- ErrTooManyRetries
+					return
+				}
 			}
 
 			// if this is the first run, we don't need to wait

--- a/onpremise/file_pulling.go
+++ b/onpremise/file_pulling.go
@@ -56,7 +56,7 @@ func (p *Engine) scheduleFilePulling() {
 
 			p.logger.Printf("Pulling data from %s", p.dataFileUrl)
 
-			fileResponse, err := doDataFileRequest(p.dataFileUrl)
+			fileResponse, err := doDataFileRequest(p.dataFileUrl, p.logger)
 			if err != nil {
 				p.logger.Printf("failed to pull data file: %v", err)
 				if fileResponse != nil && fileResponse.retryAfter > 0 {
@@ -77,6 +77,15 @@ func (p *Engine) scheduleFilePulling() {
 			}
 
 			p.logger.Printf("data file pulled successfully: %d bytes", fileResponse.buffer.Len())
+
+			if err != nil {
+				p.logger.Printf("failed to create data file: %v", err)
+				// retry after 1 second, since we have unhandled error
+				// this can happen from disk write error or something else
+				retryAttempts += 1
+				nextIterationInMs = retryMs
+				continue
+			}
 
 			err = p.createDatafileIfNotExists()
 			if err != nil {
@@ -142,7 +151,7 @@ type FileResponse struct {
 }
 
 // doDataFileRequest performs the data file request
-func doDataFileRequest(url string) (*FileResponse, error) {
+func doDataFileRequest(url string, logger logWrapper) (*FileResponse, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -173,9 +182,9 @@ func doDataFileRequest(url string) (*FileResponse, error) {
 
 	buffer := bytes.NewBuffer(make([]byte, 0))
 	_, err = buffer.ReadFrom(resp.Body)
-	contentMD5 := resp.Header.Get("Content-MD5")
+	responseBytes := buffer.Bytes()
 
-	fileBytes, err := gzip.NewReader(buffer)
+	fileBytes, err := gzip.NewReader(bytes.NewBuffer(responseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to decompress file: %v", err)
 	}
@@ -186,14 +195,18 @@ func doDataFileRequest(url string) (*FileResponse, error) {
 		return nil, fmt.Errorf("failed to read decompressed file: %v", err)
 	}
 	uncompressedBytes := uncompressedBuffer.Bytes()
+	contentMD5 := resp.Header.Get("Content-MD5")
+	if len(contentMD5) > 0 {
+		isValid, err := validateMd5(responseBytes, contentMD5)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate MD5: %v", err)
+		}
 
-	isValid, err := validateMd5(uncompressedBytes, contentMD5)
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate MD5: %v", err)
-	}
-
-	if !isValid {
-		return nil, fmt.Errorf("MD5 validation failed")
+		if !isValid {
+			return nil, fmt.Errorf("MD5 validation failed")
+		}
+	} else {
+		logger.Printf("MD5 header not found in response, skipping validation")
 	}
 
 	return &FileResponse{
@@ -210,6 +223,8 @@ func validateMd5(val []byte, hash string) (bool, error) {
 	}
 
 	strVal := hex.EncodeToString(h.Sum(nil))
+
+	fmt.Println(strVal)
 
 	return strVal == hash, nil
 }

--- a/onpremise/file_pulling_test.go
+++ b/onpremise/file_pulling_test.go
@@ -2,6 +2,7 @@ package onpremise
 
 import (
 	"bytes"
+	"errors"
 	"github.com/51Degrees/device-detection-go/v4/dd"
 	"log"
 
@@ -136,4 +137,17 @@ func TestFilePulling(t *testing.T) {
 	if deviceType != "Desktop" {
 		t.Fatalf("Expected DeviceType to be Desktop, got %s", deviceType)
 	}
+}
+
+func TestTooManyRetries(t *testing.T) {
+	config := dd.NewConfigHash(dd.Balanced)
+	_, err := New(
+		config,
+		SetLicenceKey("123"),
+		SetProduct("MyProduct"),
+	)
+	if !errors.Is(err, ErrTooManyRetries) {
+		t.Fatalf("Expected error to be ErrTooManyRetries, got %v", err)
+	}
+
 }

--- a/onpremise/file_pulling_test.go
+++ b/onpremise/file_pulling_test.go
@@ -61,7 +61,7 @@ func TestFilePulling(t *testing.T) {
 		config,
 		WithDataUpdateUrl(
 			server.URL+"/datafile",
-			2000,
+			2,
 		),
 		SetMaxRetries(2),
 	)

--- a/onpremise/file_pulling_test.go
+++ b/onpremise/file_pulling_test.go
@@ -34,7 +34,7 @@ func newMockDataFileServer() *httptest.Server {
 					return
 				}
 
-				w.Header().Add("Content-MD5", "4192ecba8d3e1a2f1c2f0644cd4322c6")
+				w.Header().Add("Content-MD5", "daebfa89ddefac8e6c4325c38f129504")
 				w.Header().Add("Content-Length", strconv.Itoa(buffer.Len()))
 
 				w.WriteHeader(http.StatusOK)
@@ -63,6 +63,7 @@ func TestFilePulling(t *testing.T) {
 			server.URL+"/datafile",
 			2000,
 		),
+		SetMaxRetries(2),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create engine: %v", err)

--- a/onpremise/file_pulling_test.go
+++ b/onpremise/file_pulling_test.go
@@ -145,6 +145,7 @@ func TestTooManyRetries(t *testing.T) {
 		config,
 		SetLicenceKey("123"),
 		SetProduct("MyProduct"),
+		SetMaxRetries(5),
 	)
 	if !errors.Is(err, ErrTooManyRetries) {
 		t.Fatalf("Expected error to be ErrTooManyRetries, got %v", err)

--- a/onpremise/onpremise.go
+++ b/onpremise/onpremise.go
@@ -286,16 +286,13 @@ func (p *Engine) appendProduct() error {
 }
 
 var (
-	ErrLicenceKeyAndProductOnlyWithDefaultDataFileUrl = errors.New("licence key and product can only be set when using default data file url")
-	ErrLicenceKeyAndProductRequired                   = errors.New("licence key and product are required")
+	ErrLicenceKeyAndProductRequired = errors.New("licence key and product are required")
 )
 
 func (p *Engine) validateAndAppendUrlParams() error {
-	if !p.isDefaultDataFileUrl() && p.hasSomeDistributorParams() {
-		return ErrLicenceKeyAndProductOnlyWithDefaultDataFileUrl
-	} else if p.isDefaultDataFileUrl() && !p.hasDefaultDistributorParams() {
+	if p.isDefaultDataFileUrl() && !p.hasDefaultDistributorParams() && p.isScheduledFilePullingEnabled {
 		return ErrLicenceKeyAndProductRequired
-	} else if p.isDefaultDataFileUrl() {
+	} else if p.isDefaultDataFileUrl() && p.isScheduledFilePullingEnabled {
 		err := p.appendLicenceKey()
 		if err != nil {
 			return err

--- a/onpremise/onpremise.go
+++ b/onpremise/onpremise.go
@@ -142,6 +142,13 @@ func SetMaxRetries(retries int) EngineOptions {
 
 }
 
+func DataDownloadEveryMs(everyMs int) EngineOptions {
+	return func(cfg *Engine) error {
+		cfg.dataFilePullEveryMs = everyMs
+		return nil
+	}
+}
+
 // ToggleLogger enables or disables the logger
 func ToggleLogger(enabled bool) EngineOptions {
 	return func(cfg *Engine) error {
@@ -171,12 +178,13 @@ func New(config *dd.ConfigHash, opts ...EngineOptions) (*Engine, error) {
 			logger:  DefaultLogger,
 			enabled: true,
 		},
-		manager:     manager,
-		config:      config,
-		rdySignal:   make(chan error, 1),
-		stopCh:      make(chan struct{}, 1),
-		fileSynced:  false,
-		dataFileUrl: defaultDataFileUrl,
+		manager:             manager,
+		config:              config,
+		rdySignal:           make(chan error, 1),
+		stopCh:              make(chan struct{}, 1),
+		fileSynced:          false,
+		dataFileUrl:         defaultDataFileUrl,
+		dataFilePullEveryMs: 30000,
 	}
 
 	for _, opt := range opts {

--- a/onpremise/onpremise.go
+++ b/onpremise/onpremise.go
@@ -26,6 +26,7 @@ type Engine struct {
 	fileSynced                    bool
 	isManagerInitialized          bool
 	product                       string
+	maxRetries                    int
 }
 
 const (
@@ -131,6 +132,14 @@ func WithDataUpdateUrl(urlStr string, everyMs int) EngineOptions {
 
 		return nil
 	}
+}
+
+func SetMaxRetries(retries int) EngineOptions {
+	return func(cfg *Engine) error {
+		cfg.maxRetries = retries
+		return nil
+	}
+
 }
 
 // ToggleLogger enables or disables the logger

--- a/onpremise/onpremise.go
+++ b/onpremise/onpremise.go
@@ -142,7 +142,7 @@ func SetMaxRetries(retries int) EngineOptions {
 
 }
 
-func DataDownloadEveryMs(everyMs int) EngineOptions {
+func SetPollingInterval(everyMs int) EngineOptions {
 	return func(cfg *Engine) error {
 		cfg.dataFilePullEveryMs = everyMs
 		return nil

--- a/onpremise/onpremise.go
+++ b/onpremise/onpremise.go
@@ -119,7 +119,7 @@ func SetProduct(product string) EngineOptions {
 }
 
 // WithDataUpdateUrl sets the URL to pull data from and the interval in milliseconds
-func WithDataUpdateUrl(urlStr string, everyMs int) EngineOptions {
+func WithDataUpdateUrl(urlStr string, seconds int) EngineOptions {
 	return func(cfg *Engine) error {
 		_, err := url.ParseRequestURI(urlStr)
 		if err != nil {
@@ -127,7 +127,7 @@ func WithDataUpdateUrl(urlStr string, everyMs int) EngineOptions {
 		}
 
 		cfg.dataFileUrl = urlStr
-		cfg.dataFilePullEveryMs = everyMs
+		cfg.dataFilePullEveryMs = seconds * 1000
 		cfg.isScheduledFilePullingEnabled = true
 
 		return nil
@@ -142,9 +142,9 @@ func SetMaxRetries(retries int) EngineOptions {
 
 }
 
-func SetPollingInterval(everyMs int) EngineOptions {
+func SetPollingInterval(seconds int) EngineOptions {
 	return func(cfg *Engine) error {
-		cfg.dataFilePullEveryMs = everyMs
+		cfg.dataFilePullEveryMs = seconds * 1000
 		return nil
 	}
 }

--- a/onpremise/onpremise_test.go
+++ b/onpremise/onpremise_test.go
@@ -38,7 +38,7 @@ func TestCustomProvider(t *testing.T) {
 				SetLicenceKey("123"),
 				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
 			},
-			expectedError: ErrLicenceKeyAndProductOnlyWithDefaultDataFileUrl.Error(),
+			expectedError: "",
 		},
 		{
 			name: "with product and custom url",
@@ -46,7 +46,7 @@ func TestCustomProvider(t *testing.T) {
 				SetProduct("MyProduct"),
 				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
 			},
-			expectedError: ErrLicenceKeyAndProductOnlyWithDefaultDataFileUrl.Error(),
+			expectedError: "",
 		},
 		{
 			name: "Invalid url",
@@ -61,6 +61,13 @@ func TestCustomProvider(t *testing.T) {
 				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
 			},
 			expectedError: "",
+		},
+		{
+			name: "with data file",
+			engineOptions: []EngineOptions{
+				WithDataFile("non existing file"),
+			},
+			expectedError: "failed to get file path: file does not exist",
 		},
 	}
 

--- a/onpremise/onpremise_test.go
+++ b/onpremise/onpremise_test.go
@@ -5,24 +5,6 @@ import (
 	"testing"
 )
 
-func TestDefaultProvider(t *testing.T) {
-	config := dd.NewConfigHash(dd.Balanced)
-	engine, err := New(
-		config,
-		SetLicenceKey("123"),
-		SetProduct("MyProduct"),
-	)
-	if err != nil {
-		t.Errorf("Failed to create engine: %v", err)
-	}
-
-	if engine.dataFileUrl != "https://distributor.51degrees.com/api/v2/download?Download=True&LicenseKeys=123&Product=MyProduct&Type=HashV41" {
-		t.Errorf("Failed to set default data file url %s", engine.dataFileUrl)
-	}
-
-	engine.Stop()
-}
-
 func TestCustomProvider(t *testing.T) {
 	mockServer := newMockDataFileServer()
 	defer mockServer.Close()

--- a/onpremise/onpremise_test.go
+++ b/onpremise/onpremise_test.go
@@ -18,7 +18,7 @@ func TestCustomProvider(t *testing.T) {
 			name: "with licence key and custom url",
 			engineOptions: []EngineOptions{
 				SetLicenceKey("123"),
-				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
+				WithDataUpdateUrl(mockServer.URL+"/datafile", 2),
 			},
 			expectedError: "",
 		},
@@ -26,21 +26,21 @@ func TestCustomProvider(t *testing.T) {
 			name: "with product and custom url",
 			engineOptions: []EngineOptions{
 				SetProduct("MyProduct"),
-				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
+				WithDataUpdateUrl(mockServer.URL+"/datafile", 2),
 			},
 			expectedError: "",
 		},
 		{
 			name: "Invalid url",
 			engineOptions: []EngineOptions{
-				WithDataUpdateUrl("dsoahdsakjhd", 2000),
+				WithDataUpdateUrl("dsoahdsakjhd", 2),
 			},
 			expectedError: `parse "dsoahdsakjhd": invalid URI for request`,
 		},
 		{
 			name: "with custom url",
 			engineOptions: []EngineOptions{
-				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
+				WithDataUpdateUrl(mockServer.URL+"/datafile", 2),
 			},
 			expectedError: "",
 		},

--- a/onpremise/onpremise_test.go
+++ b/onpremise/onpremise_test.go
@@ -1,0 +1,82 @@
+package onpremise
+
+import (
+	"github.com/51Degrees/device-detection-go/v4/dd"
+	"testing"
+)
+
+func TestDefaultProvider(t *testing.T) {
+	config := dd.NewConfigHash(dd.Balanced)
+	engine, err := New(
+		config,
+		SetLicenceKey("123"),
+		SetProduct("MyProduct"),
+	)
+	if err != nil {
+		t.Errorf("Failed to create engine: %v", err)
+	}
+
+	if engine.dataFileUrl != "https://distributor.51degrees.com/api/v2/download?Download=True&LicenseKeys=123&Product=MyProduct&Type=HashV41" {
+		t.Errorf("Failed to set default data file url %s", engine.dataFileUrl)
+	}
+
+	engine.Stop()
+}
+
+func TestCustomProvider(t *testing.T) {
+	mockServer := newMockDataFileServer()
+	defer mockServer.Close()
+
+	cases := []struct {
+		name          string
+		engineOptions []EngineOptions
+		expectedError string
+	}{
+		{
+			name: "with licence key and custom url",
+			engineOptions: []EngineOptions{
+				SetLicenceKey("123"),
+				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
+			},
+			expectedError: ErrLicenceKeyAndProductOnlyWithDefaultDataFileUrl.Error(),
+		},
+		{
+			name: "with product and custom url",
+			engineOptions: []EngineOptions{
+				SetProduct("MyProduct"),
+				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
+			},
+			expectedError: ErrLicenceKeyAndProductOnlyWithDefaultDataFileUrl.Error(),
+		},
+		{
+			name: "Invalid url",
+			engineOptions: []EngineOptions{
+				WithDataUpdateUrl("dsoahdsakjhd", 2000),
+			},
+			expectedError: `parse "dsoahdsakjhd": invalid URI for request`,
+		},
+		{
+			name: "with custom url",
+			engineOptions: []EngineOptions{
+				WithDataUpdateUrl(mockServer.URL+"/datafile", 2000),
+			},
+			expectedError: "",
+		},
+	}
+
+	config := dd.NewConfigHash(dd.Balanced)
+
+	for _, c := range cases {
+		engine, err := New(
+			config,
+			c.engineOptions...,
+		)
+		if engine != nil {
+			engine.Stop()
+		}
+		if err != nil && err.Error() != c.expectedError {
+			t.Errorf("Failed case %s: %v", c.name, err)
+		}
+
+	}
+}


### PR DESCRIPTION
features:
 options: 
    * SetLicenceKey
    * SetProduct
    * SetMaxRetries default 0, infinity, added for easier testing
    * SetPollingInterval -> default to 30s
 methods
    * GetHttpHeaderKeys
 types:
  ErrLicenceKeyAndProductRequired
  ErrTooManyRetries
  
  misc:
  * WithDataUpdateUrl now throws error if url is not in valid format
  * add more test cases
  * in case
  
  fixes: 
  * constructor was freezing if WithDataFile is provided without automatic data pulling
  * calling Stop on engine would panic in case manager was not initated and c pointer was null
  * Close channels on Stop
  * md-5 compares compressed file
  