### PR TITLE
Updated README section for running on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ In order to build use device-detection-go the following are required:
 - A C compiler that support C11 or above (Gcc on Linux, Clang on MacOS and MinGW-x64 on Windows)
 - libatomic - which usually come with default Gcc, Clang installation
 
+### Windows
+
+If you are on Windows, make sure that:
+- The path to the `MinGW-x64` `bin` folder is included in the `PATH`. By default, the path should be `C:\msys64\ucrt64\bin`
+- Go environment variable `CGO_ENABLED` is set to `1` 
+```
+go env -w CGO_ENABLED=1
+```
+
 ## Module and Packages
 
 This module name `device-detection-go` at path `github.com/51Degrees/device-detection-go/v4`
@@ -48,9 +57,6 @@ This Go Lite version contains only one single package:
 - `dd`
 
 ## Build and Usage
-
-### Windows
-If you are on Windows, make sure the path to the `MinGW-x64` `bin` folder is included in the `PATH`.
 
 ### Build steps for all platforms
 


### PR DESCRIPTION
Fix for the issue https://github.com/51Degrees/device-detection-examples-go/issues/24

When navigating to /dd/offline_processing and running go run offline_processing.go This error is produced:
github.com/51Degrees/device-detection-examples-go/v4/dd
..\example_base.go:46:28: undefined: dd.PerformanceProfile
..\example_base.go:50:22: undefined: dd.GetFilePath
..\example_base.go:106:29: undefined: dd.PerformanceProfile
..\example_base.go:107:16: undefined: dd.PerformanceProfile
..\example_base.go:110:16: undefined: dd.PerformanceProfile
..\example_base.go:111:7: undefined: dd.Default
..\example_base.go:112:7: undefined: dd.LowMemory
..\example_base.go:113:7: undefined: dd.Balanced
..\example_base.go:114:7: undefined: dd.BalancedTemp
..\example_base.go:115:7: undefined: dd.HighPerformance
..\example_base.go:115:7: too many errors