### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 51Degrees Device Detection Engines
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=go-open-source "Data rewards the curious") **Go Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-go&utm_content=readme.md&utm_term=51degrees-device-detection-engines "Data rewards the curious") **Go Device Detection**
 
 ## Introduction
 
@@ -34,7 +34,7 @@ Or download [51Degrees-LiteV4.1.hash](https://github.com/51Degrees/device-detect
 
 This 'lite' file has a significantly reduced set of properties. To obtain a
 file with a more complete set of device properties see the
-[51Degrees website](https://51degrees.com/pricing).
+[51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-go&utm_content=readme.md&utm_term=data-file).
 
 ### Software
 
@@ -58,7 +58,7 @@ This module name `device-detection-go` at path `github.com/51Degrees/device-dete
 
 This Go Lite version contains the following packages:
 - `dd` - a lower level API wrapping the C device detection library
-- `onpremise` - a higher level Engine API providing device detection and [automatic data file updates](https://51degrees.com/documentation/4.4/_features__automatic_datafile_updates.html)
+- `onpremise` - a higher level Engine API providing device detection and [automatic data file updates](https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-go&utm_content=readme.md&utm_term=module-and-packages)
 
 ## Build and Usage
 

--- a/dd/device-detection-cxx.c
+++ b/dd/device-detection-cxx.c
@@ -17688,7 +17688,7 @@ static StatusMessage messages[] = {
 		"pool. Another way to avoid this is by using an in-memory "
 		"configuration, which avoids using file handles completely, and "
 		"removes any limit on concurrency. For info see "
-		"https://51degrees.com/documentation/4.5/_device_detection__features__concurrent_processing.html?utm_source=code&utm_medium=comment&utm_campaign=common-cxx&utm_content=status.c&utm_term=insufficient_handles"},
+		"https://51degrees.com/documentation/4.5/_device_detection__features__concurrent_processing.html?utm_source=code&utm_medium=comment&utm_campaign=device-detection-go&utm_content=dd-device-detection-cxx.c&utm_term=insufficient_handles"},
 	{ COLLECTION_INDEX_OUT_OF_RANGE,
 		"Index used to retrieve an item from a collection was out of range." },
 	{ COLLECTION_OFFSET_OUT_OF_RANGE,
@@ -20971,7 +20971,7 @@ void fiftyoneDegreesResultsUserAgentFree(
  * -
  * [getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
  * -
- * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+ * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=comment&utm_campaign=device-detection-go&utm_content=dd-device-detection-cxx.c&utm_term=top)
  * - [OpenRTB 2.6
  * spec](https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf)
  *
@@ -28720,7 +28720,7 @@ const char* fiftyoneDegreesResultsHashGetNoValueReasonMessage(
 	case FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_NULL_PROFILE:
 	    return "No matching profiles could be found for the supplied evidence. "
 	        "A 'best guess' can be returned by configuring more lenient "
-	        "matching rules. See https://51degrees.com/documentation/_device_detection__features__false_positive_control.html";
+	        "matching rules. See https://51degrees.com/documentation/_device_detection__features__false_positive_control.html?utm_source=code&utm_medium=comment&utm_campaign=device-detection-go&utm_content=dd-device-detection-cxx.c&utm_term=fiftyone_degrees_results_no_value_reason_null_profile";
 	case FIFTYONE_DEGREES_RESULTS_NO_VALUE_REASON_UNKNOWN:
 	default:
 		return "The reason for missing values is unknown.";

--- a/dd/device-detection-cxx.h
+++ b/dd/device-detection-cxx.h
@@ -10726,7 +10726,7 @@ MAP_TYPE(WeightedItemList)
  * -
  * [getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
  * -
- * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+ * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=comment&utm_campaign=device-detection-go&utm_content=dd-device-detection-cxx.h&utm_term=top)
  * - [OpenRTB 2.6
  * spec](https://iabtechlab.com/wp-content/uploads/2022/04/OpenRTB-2-6_FINAL.pdf)
  *

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # 51Degrees Device Detection Engines Examples
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=go-open-source "Data rewards the curious") **Examples for Device Detection in Go**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-go&utm_content=examples-readme.md&utm_term=51degrees-device-detection-engines-examples "Data rewards the curious") **Examples for Device Detection in Go**
 
 ## Introduction
 

--- a/examples/onpremise/README.md
+++ b/examples/onpremise/README.md
@@ -4,7 +4,7 @@
 
 ## update_polling_interval
 
-Demonstrates how to set up periodic data file updates by either polling the 51degrees [distributor](https://51degrees.com/documentation/4.4/_info__distributor.html) server or a custom URL. 
+Demonstrates how to set up periodic data file updates by either polling the 51degrees [distributor](https://51degrees.com/documentation/_info__distributor.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-go&utm_content=examples-onpremise-readme.md&utm_term=update_polling_interval) server or a custom URL. 
 
 To run the example, execute the following command:
 

--- a/examples/onpremise/update_polling_interval/update_polling_interval.go
+++ b/examples/onpremise/update_polling_interval/update_polling_interval.go
@@ -41,7 +41,7 @@ func main() {
 				onpremise.WithDataFile(params.DataFile),
 
 				// For automatic updates to work you will need to provide a license key.
-				// A license key can be obtained with a subscription from https://51degrees.com/pricing
+				// A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-go&utm_content=examples-onpremise-update_polling_interval-update_polling_interval.go&utm_term=main
 				onpremise.WithLicenseKey(params.LicenseKey),
 
 				// Enable automatic updates.


### PR DESCRIPTION
Tags navigational 51degrees.com links with the standard UTM vocabulary so the Content Team can trace traffic to its exact source.

- utm_source: `github` for markdown, `code` for source comments and user-visible strings.
- utm_medium: `readme` for README files, `example` for files under examples/, `comment` for library source.
- utm_campaign: `device-detection-go`.
- utm_content: file path slug; utm_term: location within the file.

Scope:
- README.md, examples/README.md, examples/onpremise/README.md (logo image normalised from the retired Logo.ashx to /img/logo.png; /documentation/4.4/ normalised to un-versioned).
- examples/onpremise/update_polling_interval/update_polling_interval.go (comment).
- dd/device-detection-cxx.c and dd/device-detection-cxx.h (amalgamated C library: doc-comment blog links and user-visible status/result message strings; the message link previously carrying the common-cxx campaign is retagged to this repo).

Functional hosts (distributor.51degrees.com) and copyright headers are untouched. A second commit adds the `UTM link lint` workflow that runs scripts/utm-lint.ps1 from common-ci.