### PR TITLE
Call 3-arg ResultsHashCreate to fix CGO build

### DIFF
--- a/dd/device-detection-cxx.c
+++ b/dd/device-detection-cxx.c
@@ -24200,12 +24200,17 @@ EXTERNAL int fiftyoneDegreesResultsHashFromDeviceId(
  * process. e.g. Client Hints support.
  * @param manager pointer to the resource manager which manages a Hash data
  * set
+ * @param userAgentCapacity deprecated and ignored. Retained only so that
+ * integrations built against the pre-4.5 API (e.g. the HAProxy 51degrees
+ * addon, which still passes it) continue to compile unchanged. Results are
+ * now sized by the number of components determined at initialisation.
  * @param overridesCapacity number of properties that can be overridden,
  * 0 to disable overrides
  * @return newly created results structure
  */
 EXTERNAL fiftyoneDegreesResultsHash* fiftyoneDegreesResultsHashCreate(
 	fiftyoneDegreesResourceManager *manager,
+	uint32_t userAgentCapacity,
 	uint32_t overridesCapacity);
 
 /**
@@ -28195,9 +28200,15 @@ void fiftyoneDegreesResultsHashFree(
 
 fiftyoneDegreesResultsHash* fiftyoneDegreesResultsHashCreate(
 	fiftyoneDegreesResourceManager *manager,
+	uint32_t userAgentCapacity,
 	uint32_t overridesCapacity) {
 	uint32_t i;
 	ResultsHash *results;
+
+	// Kept only so callers built against the pre-4.5 API (e.g. the HAProxy
+	// 51degrees addon) still compile; results are now sized by the number of
+	// components determined at initialisation, so this value is unused.
+	(void)userAgentCapacity;
 
 	// Increment the inUse counter for the active data set so that we can
 	// track any results that are created.

--- a/dd/device-detection-cxx.h
+++ b/dd/device-detection-cxx.h
@@ -9363,12 +9363,17 @@ EXTERNAL int fiftyoneDegreesResultsHashFromDeviceId(
  * process. e.g. Client Hints support.
  * @param manager pointer to the resource manager which manages a Hash data
  * set
+ * @param userAgentCapacity deprecated and ignored. Retained only so that
+ * integrations built against the pre-4.5 API (e.g. the HAProxy 51degrees
+ * addon, which still passes it) continue to compile unchanged. Results are
+ * now sized by the number of components determined at initialisation.
  * @param overridesCapacity number of properties that can be overridden,
  * 0 to disable overrides
  * @return newly created results structure
  */
 EXTERNAL fiftyoneDegreesResultsHash* fiftyoneDegreesResultsHashCreate(
 	fiftyoneDegreesResourceManager *manager,
+	uint32_t userAgentCapacity,
 	uint32_t overridesCapacity);
 
 /**

--- a/dd/results_hash.go
+++ b/dd/results_hash.go
@@ -80,6 +80,7 @@ func NewResultsHash(
 	overridesCapacity uint32) *ResultsHash {
 	r := C.ResultsHashCreate(
 		manager.CPtr,
+		C.uint32_t(uaCapacity),
 		C.uint32_t(overridesCapacity))
 
 	// Map the items list to Go slice. This is done once so every access to


### PR DESCRIPTION
Upstream device-detection-cxx added a deprecated userAgentCapacity argument to fiftyoneDegreesResultsHashCreate, breaking the CGO build after the nightly regenerates the amalgamation. The binding now passes the user-agent capacity it already accepted.

## Changes
- Pass uaCapacity through NewResultsHash to the 3-arg ResultsHashCreate.
- Sync the committed amalgamation declaration and definition to the 3-arg signature.