### PR TITLE
FIX: Assert at least one matched User-Agent, not exactly one

### DIFF
--- a/dd/results_hash_test.go
+++ b/dd/results_hash_test.go
@@ -134,10 +134,14 @@ func TestMatchMetrics(t *testing.T) {
 			t.Error("Expected method to not be None.")
 		}
 
-		// Check User-Agents
-		if results.UserAgents() != 1 {
-			t.Error("Expected number of used User-Agents to be 1 as there was " +
-				"only one input.")
+		// Check User-Agents. Since the detection result shape was unified in
+		// device-detection-cxx (issue #362), a single User-Agent produces one
+		// result - and so one matched User-Agent - per component the engine
+		// populates, rather than exactly one overall. The number depends on the
+		// data file, so check that at least one is returned.
+		if results.UserAgents() < 1 {
+			t.Errorf("Expected at least one used User-Agent, but got %d",
+				results.UserAgents())
 		}
 
 		// Check match User-Agent string


### PR DESCRIPTION
Relates to #TASK

Updates `results_hash_test.go` for the unified detection result shape
introduced in 51Degrees/device-detection-cxx#362 (merged in
51Degrees/device-detection-cxx#385).

The test asserted that a single User-Agent produces exactly one used
User-Agent. #362 removed the fast path that coupled result shape to evidence
cardinality, so detection now produces one result - and so one matched
User-Agent - per component the engine populates. A single User-Agent yields
several rather than one.

## Change

`if results.UserAgents() != 1` becomes a lower bound of 1, reporting the actual
value on failure. The exact number depends on which components the data file
makes available, so pinning a literal would be brittle across data file
revisions. The following `results.UserAgent(0)` call remains valid for any
count of at least one.

The new assertion holds under both the old shape (1) and the new one.

## Sequencing

This module ships an amalgamation of device-detection-cxx rather than consuming
it as a submodule, so the new shape arrives whenever `dd/device-detection-cxx.c`
and `dd/device-detection-cxx.h` are next regenerated - the bundled copy is still
pre-#362. Landing this first means that regeneration does not turn the suite
red.

## Verification

Test-only change. Not executed locally - the Go toolchain and a C compiler were
not available in the environment used, and this package builds the bundled C
amalgamation through cgo. The change follows the `t.Errorf` style already used
throughout the file. CI is the check.

## Related

The same assertion is being corrected in device-detection-java,
device-detection-dotnet, device-detection-node and device-detection-python.
device-detection-php is unaffected - it asserts no result counts.
